### PR TITLE
fix: cast SignerContext to host React typings in ParaSignerProvider

### DIFF
--- a/packages/use-miden-para-react/src/ParaSignerProvider.tsx
+++ b/packages/use-miden-para-react/src/ParaSignerProvider.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   createContext,
   useContext,
+  type Context,
   type ReactNode,
 } from 'react';
 import { ParaWeb, Environment, type Wallet } from '@getpara/web-sdk';
@@ -19,10 +20,19 @@ import {
 } from '@getpara/react-sdk-lite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
-  SignerContext,
+  SignerContext as SignerContextUnsafe,
   type SignerContextValue,
   type SignerAccountConfig,
 } from '@miden-sdk/react';
+
+// Re-cast SignerContext to the host app's React typings. @miden-sdk/react may
+// ship with a different @types/react version than the consumer (common with
+// yarn link setups where the linked package has its own node_modules), which
+// causes structural Context<...> / ReactNode mismatches even though the
+// runtime value is identical. The cast is safe — it's the same React context
+// object at runtime.
+const SignerContext =
+  SignerContextUnsafe as unknown as Context<SignerContextValue | null>;
 import {
   signCb as createSignCb,
   type CustomSignConfirmStep,


### PR DESCRIPTION
## Summary
- `yarn publish:dry` was failing in `@miden-sdk/use-miden-para-react` during the dts build with `React.ReactNode` / `React.Context` incompatibilities between the package's own `@types/react` and the version resolved through `@miden-sdk/react`.
- Root cause: when `@miden-sdk/react` is resolved through a copy that ships with a different `@types/react` version (common in yarn-link setups where the linked package has its own `node_modules`), the `SignerContext`/`ReactNode` types are structurally incompatible with the host's React typings (v18 vs v19 differs on `bigint` in `ReactNode` and `$$typeof` on `Context`).
- Fix: import `SignerContext` under an alias and cast it once to the host app's `Context<SignerContextValue | null>`. Runtime-safe — same object — and makes the code resilient to `@types/react` version drift in consumer environments.

## Test plan
- [x] `yarn build` in `packages/use-miden-para-react` succeeds
- [x] `yarn publish:dry` at repo root completes all three levels successfully