### PR TITLE
chore: upgrade to miden SDK 0.15

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@
    - Dedicated tests (`tests/modalClient.test.cjs`) assert rendering, resolution semantics, and cleanup.
 3. **React integration (`packages/use-miden-para-react/src/useParaMiden.ts`)**
    - Leverages `useClient`, `useAccount`, `useWallet` (Para React SDK) to watch connection state.
-   - Lazily imports `@miden-sdk/miden-sdk` for `AccountType`, spins up the Para-backed WebClient once wallets resolve, and memoizes the resulting client in a ref.
+   - Spins up the Para-backed WebClient via `createParaMidenClient` once wallets resolve, and memoizes the resulting client in a ref.
    - Imports the root npm package (`@miden-sdk/miden-para`).
 4. **Example consumer (`examples/react/src/components/ConsumeAllNotes.tsx`)**
    - Wraps UI with `ParaProvider` + TanStack Query.

--- a/examples/react-signer/package.json
+++ b/examples/react-signer/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@getpara/react-sdk-lite": "^2.2.0",
     "@getpara/evm-wallet-connectors": "^2.2.0",
-    "@miden-sdk/miden-sdk": "^0.14.4",
-    "@miden-sdk/react": "^0.14.4",
+    "@miden-sdk/miden-sdk": "^0.15.0",
+    "@miden-sdk/react": "^0.15.0",
     "@miden-sdk/miden-para": "file:../..",
     "@miden-sdk/use-miden-para-react": "file:../../packages/use-miden-para-react",
     "@tanstack/react-query": "^5.90.12",
@@ -32,8 +32,8 @@
     "vite-plugin-wasm": "^3.5.0"
   },
   "resolutions": {
-    "@miden-sdk/miden-sdk": "^0.14.4",
-    "@miden-sdk/react": "^0.14.4"
+    "@miden-sdk/miden-sdk": "^0.15.0",
+    "@miden-sdk/react": "^0.15.0"
   },
   "packageManager": "yarn@1.22.22"
 }

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -11,12 +11,12 @@
     "postinstall": "setup-para"
   },
   "dependencies": {
-    "@miden-sdk/miden-sdk": "^0.14.4",
+    "@miden-sdk/miden-sdk": "^0.15.0",
     "@getpara/evm-wallet-connectors": "^2.2.0",
     "@getpara/react-sdk-lite": "^2.2.0",
-    "@miden-sdk/miden-para": "^0.14.1",
-    "@miden-sdk/use-miden-para-react": "^0.14.1",
-    "@miden-sdk/react": "^0.14.4",
+    "@miden-sdk/miden-para": "^0.15.0",
+    "@miden-sdk/use-miden-para-react": "^0.15.0",
+    "@miden-sdk/react": "^0.15.0",
     "@tanstack/react-query": "^5.90.12",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-para",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Miden x Para Integration",
   "packageManager": "yarn@4.9.3",
   "workspaces": [
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@getpara/web-sdk": "^2.11.0",
-    "@miden-sdk/miden-sdk": "^0.14.4",
+    "@miden-sdk/miden-sdk": "^0.15.0",
     "@types/react": "^19.0.0",
     "@typescript-eslint/parser": "^8.48.0",
     "esbuild": "^0.24.0",
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "@getpara/web-sdk": "^2.11.0",
-    "@miden-sdk/miden-sdk": "^0.14.4"
+    "@miden-sdk/miden-sdk": "^0.15.0"
   },
   "exports": {
     ".": {

--- a/packages/create-miden-para-react/bin/create-miden-para-react.mjs
+++ b/packages/create-miden-para-react/bin/create-miden-para-react.mjs
@@ -216,19 +216,19 @@ function ensureMidenParaDependencies(targetRoot) {
   pkg.scripts = pkg.scripts ?? {};
   const midenParaVersion = useLocalDeps
     ? `file:${localMidenParaPath}`
-    : "0.14.0";
+    : "0.15.0";
   const useMidenParaReactVersion = useLocalDeps
     ? `file:${localUseMidenParaReactPath}`
-    : "^0.14.0";
+    : "^0.15.0";
   // Align with examples/react-signer so Para SDK connector peers are satisfied
   Object.assign(pkg.dependencies, {
     ...pkg.dependencies,
     "@getpara/react-sdk-lite": "^2.2.0",
     "@getpara/evm-wallet-connectors": "^2.2.0",
-    "@miden-sdk/miden-sdk": "^0.14.0",
+    "@miden-sdk/miden-sdk": "^0.15.0",
     "@miden-sdk/miden-para": midenParaVersion,
     "@miden-sdk/use-miden-para-react": useMidenParaReactVersion,
-    "@miden-sdk/react": "^0.14.0",
+    "@miden-sdk/react": "^0.15.0",
     "@tanstack/react-query": "^5.0.0",
   });
 

--- a/packages/create-miden-para-react/package.json
+++ b/packages/create-miden-para-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/create-miden-para-react",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Create a Vite react-ts app preconfigured with Miden + Para's Vite setup",
   "type": "module",
   "bin": "./bin/create-miden-para-react.mjs",

--- a/packages/use-miden-para-react/AGENTS.md
+++ b/packages/use-miden-para-react/AGENTS.md
@@ -17,7 +17,7 @@
 1. Read Para context via `useClient`, `useAccount`, `useWallet`.
 2. Memoize `evmWallets` from the embedded wallet list.
 3. `useEffect` guards against running before Para connects or when a client already exists.
-4. Lazily import `@miden-sdk/miden-sdk` for `AccountType` and call `createParaMidenClient` from the root package, passing node endpoint + storage mode.
+4. Call `createParaMidenClient` from the root package, passing node endpoint + storage mode.
 5. Persist the resulting client in a ref (so rerenders don’t trigger rebuilds) and expose the resolved `accountId`.
 
 ## Agent Playbooks
@@ -29,4 +29,4 @@
 ## External Contracts
 - `@getpara/react-sdk-lite` — supplies `useClient`, `useAccount`, `useWallet`, and Para configuration context. Hook must only run when `useAccount().isConnected` is true.
 - `@miden-sdk/miden-para` — root SDK; `createParaMidenClient` handles modal UX and signing. Ensure versions stay compatible (`peerDependencies` enforce `^0.13.0`+).
-- `@miden-sdk/miden-sdk` — dynamically imported for runtime helpers like `AccountType`. Keep it externalized to avoid bundling WASM assets.
+- `@miden-sdk/miden-sdk` — dynamically imported for runtime helpers like `AccountStorageMode`. Keep it externalized to avoid bundling WASM assets.

--- a/packages/use-miden-para-react/package.json
+++ b/packages/use-miden-para-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/use-miden-para-react",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "React hook that wires Para accounts into a Miden client",
   "license": "MIT",
   "author": "Miden Labs",
@@ -45,9 +45,9 @@
   "peerDependencies": {
     "@getpara/react-sdk-lite": "^2.11.0",
     "@getpara/web-sdk": "^2.11.0",
-    "@miden-sdk/miden-para": "^0.14.1",
-    "@miden-sdk/miden-sdk": "^0.14.4",
-    "@miden-sdk/react": "^0.14.4",
+    "@miden-sdk/miden-para": "^0.15.0",
+    "@miden-sdk/miden-sdk": "^0.15.0",
+    "@miden-sdk/react": "^0.15.0",
     "@tanstack/react-query": "^5.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "vite-plugin-node-polyfills": "^0.22.0"
@@ -60,8 +60,8 @@
   "devDependencies": {
     "@getpara/react-sdk-lite": "^2.11.0",
     "@getpara/web-sdk": "^2.11.0",
-    "@miden-sdk/miden-sdk": "^0.14.4",
-    "@miden-sdk/react": "^0.14.4",
+    "@miden-sdk/miden-sdk": "^0.15.0",
+    "@miden-sdk/react": "^0.15.0",
     "@tanstack/react-query": "^5.90.12",
     "@types/node": "^25.3.5",
     "@types/react": "^19.2.5",

--- a/packages/use-miden-para-react/src/ParaSignerProvider.tsx
+++ b/packages/use-miden-para-react/src/ParaSignerProvider.tsx
@@ -299,7 +299,6 @@ function ParaSignerProviderInner({
             signCb: signCallback,
             accountConfig: {
               publicKeyCommitment: commitmentBytes,
-              accountType: 'RegularAccountImmutableCode',
               storageMode: AccountStorageMode.public(),
               ...(customComponents?.length ? { customComponents } : {}),
               ...(importAccountId ? { importAccountId } : {}),

--- a/packages/use-miden-para-react/src/useParaMiden.ts
+++ b/packages/use-miden-para-react/src/useParaMiden.ts
@@ -27,7 +27,7 @@ import {
 export function useParaMiden(
   nodeUrl: string,
   storageMode: MidenAccountStorageMode = 'public',
-  opts: Omit<Opts, 'endpoint' | 'type' | 'storageMode'> = {},
+  opts: Omit<Opts, 'endpoint' | 'storageMode'> = {},
   showSigningModal: boolean = true,
   customSignConfirmStep?: CustomSignConfirmStep
 ) {
@@ -54,8 +54,6 @@ export function useParaMiden(
         return;
       }
 
-      const { AccountType } = await import('@miden-sdk/miden-sdk');
-
       const { client: midenParaClient, accountId: aId } =
         await createParaMidenClient(
           para,
@@ -63,7 +61,6 @@ export function useParaMiden(
           {
             ...opts,
             endpoint: nodeUrl,
-            type: AccountType.RegularAccountImmutableCode,
             storageMode,
           },
           showSigningModal,

--- a/src/midenClient.ts
+++ b/src/midenClient.ts
@@ -61,7 +61,7 @@ export const signCb = (
 
 /**
  * Ensures a Miden account exists for the given Para wallet public key.
- * Attempts to import an existing account for public/network modes before creating a new one.
+ * Attempts to import an existing account for public mode before creating a new one.
  */
 async function createAccount(
   client: MidenClient,
@@ -78,26 +78,22 @@ async function createAccount(
     accountSeedFromStr(opts.accountSeed) ?? new Uint8Array(32).fill(0)
   );
 
-  let accountStorageMode;
-
-  if (opts.storageMode === 'public') {
-    accountStorageMode = AccountStorageMode.public();
-  } else if (opts.storageMode === 'private') {
-    accountStorageMode = AccountStorageMode.private();
-  } else {
-    accountStorageMode = AccountStorageMode.network();
-  }
+  // In protocol 0.15 the account type IS the storage mode (public/private visibility);
+  // faucet-vs-wallet is determined by the components, not an account-type flag.
+  const accountStorageMode =
+    opts.storageMode === 'private'
+      ? AccountStorageMode.private()
+      : AccountStorageMode.public();
 
   const account = accountBuilder
     .withAuthComponent(
       AccountComponent.createAuthComponentFromCommitment(pkc, 1)
     )
-    .accountType(opts.type)
     .storageMode(accountStorageMode)
     .withBasicWalletComponent()
     .build().account;
 
-  // If the account already exists on-chain (e.g. public/network), hydrate it instead of
+  // If the account already exists on-chain (e.g. public), hydrate it instead of
   // recreating a “new” account with zero commitment, which causes submission to fail.
   if (opts.storageMode !== 'private') {
     try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,3 @@
-import type { AccountType } from '@miden-sdk/miden-sdk';
-
 export interface MidenClientOpts {
   endpoint?: string;
   noteTransportUrl?: string;
@@ -10,11 +8,10 @@ export interface MidenClientOpts {
   seed?: string;
 }
 
-export type MidenAccountStorageMode = 'public' | 'private' | 'network';
+export type MidenAccountStorageMode = 'public' | 'private';
 
 export interface MidenAccountOpts {
   accountSeed?: string;
-  type: AccountType;
   storageMode: MidenAccountStorageMode;
 }
 export type Opts = MidenClientOpts & MidenAccountOpts;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -132,10 +132,11 @@ export const txSummaryToJosn = (
 };
 
 function noteTypeToString(noteType: NoteType) {
+  // protocol 0.15 NoteType encoding: Private = 0, Public = 1.
   switch (noteType) {
     case 1:
       return 'public';
-    case 2:
+    case 0:
       return 'private';
     default:
       return 'UNKNOWN';

--- a/tests/useParaMiden.test.cjs
+++ b/tests/useParaMiden.test.cjs
@@ -104,9 +104,7 @@ const buildMocks = (state, calls, client) => ({
       return { client, accountId: 'acc-123' };
     },
   },
-  '@miden-sdk/miden-sdk': {
-    AccountType: { RegularAccountImmutableCode: 'RegularAccountImmutableCode' },
-  },
+  '@miden-sdk/miden-sdk': {},
 });
 
 test('useParaMiden returns defaults when disconnected', async () => {
@@ -179,7 +177,6 @@ test('useParaMiden filters EVM wallets and forwards options', async () => {
       optsArg.noteTransportUrl,
       'https://transport.miden.io'
     );
-    assert.strictEqual(optsArg.type, 'RegularAccountImmutableCode');
     assert.strictEqual(showSigningModalArg, false);
     assert.strictEqual(confirmArg, confirmStep);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1086,7 +1086,7 @@ __metadata:
   resolution: "@miden-sdk/miden-para@workspace:."
   dependencies:
     "@getpara/web-sdk": "npm:^2.11.0"
-    "@miden-sdk/miden-sdk": "npm:^0.14.4"
+    "@miden-sdk/miden-sdk": "npm:^0.15.0"
     "@noble/hashes": "npm:^2.0.1"
     "@types/react": "npm:^19.0.0"
     "@typescript-eslint/parser": "npm:^8.48.0"
@@ -1100,30 +1100,60 @@ __metadata:
     typescript: "npm:^5.8.3"
   peerDependencies:
     "@getpara/web-sdk": ^2.11.0
-    "@miden-sdk/miden-sdk": ^0.14.4
+    "@miden-sdk/miden-sdk": ^0.15.0
   languageName: unknown
   linkType: soft
 
-"@miden-sdk/miden-sdk@npm:^0.14.4":
-  version: 0.14.4
-  resolution: "@miden-sdk/miden-sdk@npm:0.14.4"
+"@miden-sdk/miden-sdk@npm:^0.15.0":
+  version: 0.15.0
+  resolution: "@miden-sdk/miden-sdk@npm:0.15.0"
   dependencies:
-    "@rollup/plugin-typescript": "npm:^12.3.0"
+    "@miden-sdk/node-darwin-arm64": "npm:0.15.0"
+    "@miden-sdk/node-darwin-x64": "npm:0.15.0"
+    "@miden-sdk/node-linux-x64-gnu": "npm:0.15.0"
     dexie: "npm:^4.0.1"
     glob: "npm:^11.0.0"
-  checksum: 10c0/0eb292b680665a1019cec8531518a96c9e5389acd6b99a18487e2a8167374ca9c858da36bf49d9222e6bfa0b6c35dc38414daa9ddb7ee59e1b27f3abd762ce22
+  dependenciesMeta:
+    "@miden-sdk/node-darwin-arm64":
+      optional: true
+    "@miden-sdk/node-darwin-x64":
+      optional: true
+    "@miden-sdk/node-linux-x64-gnu":
+      optional: true
+  checksum: 10c0/94b1849c584c5480893ab368dc491e1b73487c89551324fc57fd0eba15287802a8581e3ebaf1ebd8ea66ffc3387ba88703ddb3a8621d1de3bbf4df1d9b5a108e
   languageName: node
   linkType: hard
 
-"@miden-sdk/react@npm:^0.14.4":
-  version: 0.14.4
-  resolution: "@miden-sdk/react@npm:0.14.4"
+"@miden-sdk/node-darwin-arm64@npm:0.15.0":
+  version: 0.15.0
+  resolution: "@miden-sdk/node-darwin-arm64@npm:0.15.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@miden-sdk/node-darwin-x64@npm:0.15.0":
+  version: 0.15.0
+  resolution: "@miden-sdk/node-darwin-x64@npm:0.15.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@miden-sdk/node-linux-x64-gnu@npm:0.15.0":
+  version: 0.15.0
+  resolution: "@miden-sdk/node-linux-x64-gnu@npm:0.15.0"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@miden-sdk/react@npm:^0.15.0":
+  version: 0.15.0
+  resolution: "@miden-sdk/react@npm:0.15.0"
   dependencies:
     zustand: "npm:^5.0.0"
   peerDependencies:
-    "@miden-sdk/miden-sdk": ^0.14.4
+    "@miden-sdk/miden-sdk": ^0.15.0
     react: ">=18.0.0"
-  checksum: 10c0/503a4631361e0b8d1737665373b988fabb7eec77957673cc739fd20d5b58e89815fb1445c248a22237352da9f15d9393fd14448c5289199746420a8c8be00325
+  checksum: 10c0/1e9673785547b06d9a68de7fa72cf11bfd05045d19eae90df4cf9350ef38e29795478883bd9aaef78a0866e87682d1e5b48cff15c1537550d398b6d25e3a585f
   languageName: node
   linkType: hard
 
@@ -1133,8 +1163,8 @@ __metadata:
   dependencies:
     "@getpara/react-sdk-lite": "npm:^2.11.0"
     "@getpara/web-sdk": "npm:^2.11.0"
-    "@miden-sdk/miden-sdk": "npm:^0.14.4"
-    "@miden-sdk/react": "npm:^0.14.4"
+    "@miden-sdk/miden-sdk": "npm:^0.15.0"
+    "@miden-sdk/react": "npm:^0.15.0"
     "@tanstack/react-query": "npm:^5.90.12"
     "@types/node": "npm:^25.3.5"
     "@types/react": "npm:^19.2.5"
@@ -1144,9 +1174,9 @@ __metadata:
   peerDependencies:
     "@getpara/react-sdk-lite": ^2.11.0
     "@getpara/web-sdk": ^2.11.0
-    "@miden-sdk/miden-para": ^0.14.1
-    "@miden-sdk/miden-sdk": ^0.14.4
-    "@miden-sdk/react": ^0.14.4
+    "@miden-sdk/miden-para": ^0.15.0
+    "@miden-sdk/miden-sdk": ^0.15.0
+    "@miden-sdk/react": ^0.15.0
     "@tanstack/react-query": ^5.0.0
     react: ^18.0.0 || ^19.0.0
     vite-plugin-node-polyfills: ^0.22.0
@@ -1273,41 +1303,6 @@ __metadata:
   bin:
     browsers: lib/cjs/main-cli.js
   checksum: 10c0/90c761200da538234100a7f7cd0677c60cfcfbf710445fb2d82ece34bf3b5a015958919d110d7041a0680fe1d690e3e7737594fe2efd6a7dac8681ef646ecc3e
-  languageName: node
-  linkType: hard
-
-"@rollup/plugin-typescript@npm:^12.3.0":
-  version: 12.3.0
-  resolution: "@rollup/plugin-typescript@npm:12.3.0"
-  dependencies:
-    "@rollup/pluginutils": "npm:^5.1.0"
-    resolve: "npm:^1.22.1"
-  peerDependencies:
-    rollup: ^2.14.0||^3.0.0||^4.0.0
-    tslib: "*"
-    typescript: ">=3.7.0"
-  peerDependenciesMeta:
-    rollup:
-      optional: true
-    tslib:
-      optional: true
-  checksum: 10c0/41d14e9a9792d8d9751c275cf87c2de796ddd1a64c96fedc622baad8cfbb1247537e37ae428e59e1850de7d7165941ee1a4030dbe9bebd5fbb38c5e4f751d8b5
-  languageName: node
-  linkType: hard
-
-"@rollup/pluginutils@npm:^5.1.0":
-  version: 5.3.0
-  resolution: "@rollup/pluginutils@npm:5.3.0"
-  dependencies:
-    "@types/estree": "npm:^1.0.0"
-    estree-walker: "npm:^2.0.2"
-    picomatch: "npm:^4.0.2"
-  peerDependencies:
-    rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-  peerDependenciesMeta:
-    rollup:
-      optional: true
-  checksum: 10c0/001834bf62d7cf5bac424d2617c113f7f7d3b2bf3c1778cbcccb72cdc957b68989f8e7747c782c2b911f1dde8257f56f8ac1e779e29e74e638e3f1e2cac2bcd0
   languageName: node
   linkType: hard
 
@@ -1667,7 +1662,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:1.0.8, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6":
+"@types/estree@npm:1.0.8, @types/estree@npm:^1.0.6":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
@@ -2928,13 +2923,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"estree-walker@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "estree-walker@npm:2.0.2"
-  checksum: 10c0/53a6c54e2019b8c914dc395890153ffdc2322781acf4bd7d1a32d7aedc1710807bdcd866ac133903d5629ec601fbb50abe8c2e5553c7f5a0afdd9b6af6c945af
-  languageName: node
-  linkType: hard
-
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
@@ -3504,15 +3492,6 @@ __metadata:
   version: 0.2.1
   resolution: "is-arrayish@npm:0.2.1"
   checksum: 10c0/e7fb686a739068bb70f860b39b67afc62acc62e36bb61c5f965768abce1873b379c563e61dd2adad96ebb7edf6651111b385e490cf508378959b0ed4cac4e729
-  languageName: node
-  linkType: hard
-
-"is-core-module@npm:^2.16.1":
-  version: 2.16.1
-  resolution: "is-core-module@npm:2.16.1"
-  dependencies:
-    hasown: "npm:^2.0.2"
-  checksum: 10c0/898443c14780a577e807618aaae2b6f745c8538eca5c7bc11388a3f2dc6de82b9902bcc7eb74f07be672b11bbe82dd6a6edded44a00cb3d8f933d0459905eedd
   languageName: node
   linkType: hard
 
@@ -4175,13 +4154,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-parse@npm:^1.0.7":
-  version: 1.0.7
-  resolution: "path-parse@npm:1.0.7"
-  checksum: 10c0/11ce261f9d294cc7a58d6a574b7f1b935842355ec66fba3c3fd79e0f036462eaf07d0aa95bb74ff432f9afef97ce1926c720988c6a7451d8a584930ae7de86e1
-  languageName: node
-  linkType: hard
-
 "path-scurry@npm:^2.0.0, path-scurry@npm:^2.0.2":
   version: 2.0.2
   resolution: "path-scurry@npm:2.0.2"
@@ -4213,7 +4185,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3, picomatch@npm:^4.0.4":
+"picomatch@npm:^4.0.3, picomatch@npm:^4.0.4":
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
@@ -4490,32 +4462,6 @@ __metadata:
   version: 5.0.0
   resolution: "resolve-from@npm:5.0.0"
   checksum: 10c0/b21cb7f1fb746de8107b9febab60095187781137fd803e6a59a76d421444b1531b641bba5857f5dc011974d8a5c635d61cec49e6bd3b7fc20e01f0fafc4efbf2
-  languageName: node
-  linkType: hard
-
-"resolve@npm:^1.22.1":
-  version: 1.22.11
-  resolution: "resolve@npm:1.22.11"
-  dependencies:
-    is-core-module: "npm:^2.16.1"
-    path-parse: "npm:^1.0.7"
-    supports-preserve-symlinks-flag: "npm:^1.0.0"
-  bin:
-    resolve: bin/resolve
-  checksum: 10c0/f657191507530f2cbecb5815b1ee99b20741ea6ee02a59c57028e9ec4c2c8d7681afcc35febbd554ac0ded459db6f2d8153382c53a2f266cee2575e512674409
-  languageName: node
-  linkType: hard
-
-"resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>":
-  version: 1.22.11
-  resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=c3c19d"
-  dependencies:
-    is-core-module: "npm:^2.16.1"
-    path-parse: "npm:^1.0.7"
-    supports-preserve-symlinks-flag: "npm:^1.0.0"
-  bin:
-    resolve: bin/resolve
-  checksum: 10c0/ee5b182f2e37cb1165465e58c6abc797fec0a80b5ba3231607beb4677db0c9291ac010c47cf092b6daa2b7f518d69a0e21888e7e2b633f68d501a874212a8c63
   languageName: node
   linkType: hard
 
@@ -4851,13 +4797,6 @@ __metadata:
   dependencies:
     has-flag: "npm:^4.0.0"
   checksum: 10c0/afb4c88521b8b136b5f5f95160c98dee7243dc79d5432db7efc27efb219385bbc7d9427398e43dd6cc730a0f87d5085ce1652af7efbe391327bc0a7d0f7fc124
-  languageName: node
-  linkType: hard
-
-"supports-preserve-symlinks-flag@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
-  checksum: 10c0/6c4032340701a9950865f7ae8ef38578d8d7053f5e10518076e6554a9381fa91bd9c6850193695c141f32b21f979c985db07265a758867bac95de05f7d8aeb39
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Upgrades `@miden-sdk/miden-para` (and the `use-miden-para-react` / `create-miden-para-react` packages) from the `0.14` JS SDK to **`0.15.0`**, applying the Web/React breaking changes from the 0.15 migration and bumping package versions to `0.15.0` in lockstep.

## Breaking changes handled (0.14 → 0.15 SDK)

- **`AccountType` narrowed to `{ Private, Public }`.** The old `RegularAccountImmutableCode` variant is gone, and `AccountBuilder.accountType()` now sets the same visibility flag as `.storageMode()`. Removed the now-meaningless public `MidenAccountOpts.type` field and the `.accountType()` call (faucet-vs-wallet is determined by components; visibility comes from `.storageMode()`).
- **`AccountStorageMode.network()` removed.** Dropped `'network'` from `MidenAccountStorageMode` and the network branch in `createAccount`.
- **`NoteType` re-encoded** (`Private = 0`, `Public = 1`). Fixed `noteTypeToString` (the old `2 → private` mapping was dead).
- **`SignerAccountConfig.accountType` deprecated/ignored in `@miden-sdk/react` 0.15.** Removed it from the Para signer context.

## Other changes

- Bumped all `@miden-sdk/*` dependency ranges to `^0.15.0` (root, `use-miden-para-react`, both examples, and the scaffolder's pinned versions).
- Bumped package versions `0.14.1 → 0.15.0` and internal workspace refs to `^0.15.0`.
- Updated the `useParaMiden` unit test and stale `AGENTS.md` notes to match.

## ⚠️ Consumer-facing API change

The public `MidenAccountOpts.type` field was **removed** (it had no meaning under 0.15). Callers that constructed `MidenAccountOpts` / `Opts` with a `type` should drop it; account visibility is controlled solely via `storageMode` (`'public' | 'private'`). The `'network'` storage mode is also no longer accepted.

## Verification

All CI gates were run locally and pass:

- `npm test` (unit) — 27 pass
- root `npm run build` (esbuild + tsc)
- `yarn workspace @miden-sdk/use-miden-para-react build` (tsup + dts type-check)
- `yarn install --immutable`
- create-template build e2e (`RUN_CREATE_MIDEN_PARA_E2E=1`) — scaffolds a fresh app, installs the published `@miden-sdk/*@^0.15.0`, and `vite build` succeeds
- example-app puppeteer e2e (`RUN_EXAMPLE_E2E=1`) — installs `examples/react` and renders

Type-checked against the actual `0.15.0` `.d.ts` (not just the migration guide).
