### PR TITLE
chore: bump miden SDK to 0.15.1

### DIFF
--- a/examples/react-signer/package.json
+++ b/examples/react-signer/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@getpara/react-sdk-lite": "^2.2.0",
     "@getpara/evm-wallet-connectors": "^2.2.0",
-    "@miden-sdk/miden-sdk": "^0.15.0",
-    "@miden-sdk/react": "^0.15.0",
+    "@miden-sdk/miden-sdk": "^0.15.1",
+    "@miden-sdk/react": "^0.15.1",
     "@miden-sdk/miden-para": "file:../..",
     "@miden-sdk/use-miden-para-react": "file:../../packages/use-miden-para-react",
     "@tanstack/react-query": "^5.90.12",
@@ -32,8 +32,8 @@
     "vite-plugin-wasm": "^3.5.0"
   },
   "resolutions": {
-    "@miden-sdk/miden-sdk": "^0.15.0",
-    "@miden-sdk/react": "^0.15.0"
+    "@miden-sdk/miden-sdk": "^0.15.1",
+    "@miden-sdk/react": "^0.15.1"
   },
   "packageManager": "yarn@1.22.22"
 }

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -11,12 +11,12 @@
     "postinstall": "setup-para"
   },
   "dependencies": {
-    "@miden-sdk/miden-sdk": "^0.15.0",
+    "@miden-sdk/miden-sdk": "^0.15.1",
     "@getpara/evm-wallet-connectors": "^2.2.0",
     "@getpara/react-sdk-lite": "^2.2.0",
-    "@miden-sdk/miden-para": "^0.15.0",
-    "@miden-sdk/use-miden-para-react": "^0.15.0",
-    "@miden-sdk/react": "^0.15.0",
+    "@miden-sdk/miden-para": "^0.15.1",
+    "@miden-sdk/use-miden-para-react": "^0.15.1",
+    "@miden-sdk/react": "^0.15.1",
     "@tanstack/react-query": "^5.90.12",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-para",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Miden x Para Integration",
   "packageManager": "yarn@4.9.3",
   "workspaces": [
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@getpara/web-sdk": "^2.11.0",
-    "@miden-sdk/miden-sdk": "^0.15.0",
+    "@miden-sdk/miden-sdk": "^0.15.1",
     "@types/react": "^19.0.0",
     "@typescript-eslint/parser": "^8.48.0",
     "esbuild": "^0.24.0",
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "@getpara/web-sdk": "^2.11.0",
-    "@miden-sdk/miden-sdk": "^0.15.0"
+    "@miden-sdk/miden-sdk": "^0.15.1"
   },
   "exports": {
     ".": {

--- a/packages/create-miden-para-react/bin/create-miden-para-react.mjs
+++ b/packages/create-miden-para-react/bin/create-miden-para-react.mjs
@@ -216,19 +216,19 @@ function ensureMidenParaDependencies(targetRoot) {
   pkg.scripts = pkg.scripts ?? {};
   const midenParaVersion = useLocalDeps
     ? `file:${localMidenParaPath}`
-    : "0.15.0";
+    : "0.15.1";
   const useMidenParaReactVersion = useLocalDeps
     ? `file:${localUseMidenParaReactPath}`
-    : "^0.15.0";
+    : "^0.15.1";
   // Align with examples/react-signer so Para SDK connector peers are satisfied
   Object.assign(pkg.dependencies, {
     ...pkg.dependencies,
     "@getpara/react-sdk-lite": "^2.2.0",
     "@getpara/evm-wallet-connectors": "^2.2.0",
-    "@miden-sdk/miden-sdk": "^0.15.0",
+    "@miden-sdk/miden-sdk": "^0.15.1",
     "@miden-sdk/miden-para": midenParaVersion,
     "@miden-sdk/use-miden-para-react": useMidenParaReactVersion,
-    "@miden-sdk/react": "^0.15.0",
+    "@miden-sdk/react": "^0.15.1",
     "@tanstack/react-query": "^5.0.0",
   });
 

--- a/packages/create-miden-para-react/package.json
+++ b/packages/create-miden-para-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/create-miden-para-react",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Create a Vite react-ts app preconfigured with Miden + Para's Vite setup",
   "type": "module",
   "bin": "./bin/create-miden-para-react.mjs",

--- a/packages/use-miden-para-react/package.json
+++ b/packages/use-miden-para-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/use-miden-para-react",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "React hook that wires Para accounts into a Miden client",
   "license": "MIT",
   "author": "Miden Labs",
@@ -45,9 +45,9 @@
   "peerDependencies": {
     "@getpara/react-sdk-lite": "^2.11.0",
     "@getpara/web-sdk": "^2.11.0",
-    "@miden-sdk/miden-para": "^0.15.0",
-    "@miden-sdk/miden-sdk": "^0.15.0",
-    "@miden-sdk/react": "^0.15.0",
+    "@miden-sdk/miden-para": "^0.15.1",
+    "@miden-sdk/miden-sdk": "^0.15.1",
+    "@miden-sdk/react": "^0.15.1",
     "@tanstack/react-query": "^5.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "vite-plugin-node-polyfills": "^0.22.0"
@@ -60,8 +60,8 @@
   "devDependencies": {
     "@getpara/react-sdk-lite": "^2.11.0",
     "@getpara/web-sdk": "^2.11.0",
-    "@miden-sdk/miden-sdk": "^0.15.0",
-    "@miden-sdk/react": "^0.15.0",
+    "@miden-sdk/miden-sdk": "^0.15.1",
+    "@miden-sdk/react": "^0.15.1",
     "@tanstack/react-query": "^5.90.12",
     "@types/node": "^25.3.5",
     "@types/react": "^19.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1086,7 +1086,7 @@ __metadata:
   resolution: "@miden-sdk/miden-para@workspace:."
   dependencies:
     "@getpara/web-sdk": "npm:^2.11.0"
-    "@miden-sdk/miden-sdk": "npm:^0.15.0"
+    "@miden-sdk/miden-sdk": "npm:^0.15.1"
     "@noble/hashes": "npm:^2.0.1"
     "@types/react": "npm:^19.0.0"
     "@typescript-eslint/parser": "npm:^8.48.0"
@@ -1100,17 +1100,17 @@ __metadata:
     typescript: "npm:^5.8.3"
   peerDependencies:
     "@getpara/web-sdk": ^2.11.0
-    "@miden-sdk/miden-sdk": ^0.15.0
+    "@miden-sdk/miden-sdk": ^0.15.1
   languageName: unknown
   linkType: soft
 
-"@miden-sdk/miden-sdk@npm:^0.15.0":
-  version: 0.15.0
-  resolution: "@miden-sdk/miden-sdk@npm:0.15.0"
+"@miden-sdk/miden-sdk@npm:^0.15.1":
+  version: 0.15.1
+  resolution: "@miden-sdk/miden-sdk@npm:0.15.1"
   dependencies:
-    "@miden-sdk/node-darwin-arm64": "npm:0.15.0"
-    "@miden-sdk/node-darwin-x64": "npm:0.15.0"
-    "@miden-sdk/node-linux-x64-gnu": "npm:0.15.0"
+    "@miden-sdk/node-darwin-arm64": "npm:0.15.1"
+    "@miden-sdk/node-darwin-x64": "npm:0.15.1"
+    "@miden-sdk/node-linux-x64-gnu": "npm:0.15.1"
     dexie: "npm:^4.0.1"
     glob: "npm:^11.0.0"
   dependenciesMeta:
@@ -1120,40 +1120,40 @@ __metadata:
       optional: true
     "@miden-sdk/node-linux-x64-gnu":
       optional: true
-  checksum: 10c0/94b1849c584c5480893ab368dc491e1b73487c89551324fc57fd0eba15287802a8581e3ebaf1ebd8ea66ffc3387ba88703ddb3a8621d1de3bbf4df1d9b5a108e
+  checksum: 10c0/6ace9a5da79df693e32f874adcb011d1dda927a8bafe3cbb65d725e9a17df3106b24b3d21dcd60e10274e13633c9fca08d42ba757e3abac4c598c1c8119dd143
   languageName: node
   linkType: hard
 
-"@miden-sdk/node-darwin-arm64@npm:0.15.0":
-  version: 0.15.0
-  resolution: "@miden-sdk/node-darwin-arm64@npm:0.15.0"
+"@miden-sdk/node-darwin-arm64@npm:0.15.1":
+  version: 0.15.1
+  resolution: "@miden-sdk/node-darwin-arm64@npm:0.15.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@miden-sdk/node-darwin-x64@npm:0.15.0":
-  version: 0.15.0
-  resolution: "@miden-sdk/node-darwin-x64@npm:0.15.0"
+"@miden-sdk/node-darwin-x64@npm:0.15.1":
+  version: 0.15.1
+  resolution: "@miden-sdk/node-darwin-x64@npm:0.15.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@miden-sdk/node-linux-x64-gnu@npm:0.15.0":
-  version: 0.15.0
-  resolution: "@miden-sdk/node-linux-x64-gnu@npm:0.15.0"
+"@miden-sdk/node-linux-x64-gnu@npm:0.15.1":
+  version: 0.15.1
+  resolution: "@miden-sdk/node-linux-x64-gnu@npm:0.15.1"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@miden-sdk/react@npm:^0.15.0":
-  version: 0.15.0
-  resolution: "@miden-sdk/react@npm:0.15.0"
+"@miden-sdk/react@npm:^0.15.1":
+  version: 0.15.1
+  resolution: "@miden-sdk/react@npm:0.15.1"
   dependencies:
     zustand: "npm:^5.0.0"
   peerDependencies:
-    "@miden-sdk/miden-sdk": ^0.15.0
+    "@miden-sdk/miden-sdk": ^0.15.1
     react: ">=18.0.0"
-  checksum: 10c0/1e9673785547b06d9a68de7fa72cf11bfd05045d19eae90df4cf9350ef38e29795478883bd9aaef78a0866e87682d1e5b48cff15c1537550d398b6d25e3a585f
+  checksum: 10c0/a09e3cb81e8e196be18ffd0ff6620d4dd6a24910bdc9f32166e162b9966cf0518232426799f543021b657fd063130374e6178548cc434e2fbf49f7c3ad11e5f2
   languageName: node
   linkType: hard
 
@@ -1163,8 +1163,8 @@ __metadata:
   dependencies:
     "@getpara/react-sdk-lite": "npm:^2.11.0"
     "@getpara/web-sdk": "npm:^2.11.0"
-    "@miden-sdk/miden-sdk": "npm:^0.15.0"
-    "@miden-sdk/react": "npm:^0.15.0"
+    "@miden-sdk/miden-sdk": "npm:^0.15.1"
+    "@miden-sdk/react": "npm:^0.15.1"
     "@tanstack/react-query": "npm:^5.90.12"
     "@types/node": "npm:^25.3.5"
     "@types/react": "npm:^19.2.5"
@@ -1174,9 +1174,9 @@ __metadata:
   peerDependencies:
     "@getpara/react-sdk-lite": ^2.11.0
     "@getpara/web-sdk": ^2.11.0
-    "@miden-sdk/miden-para": ^0.15.0
-    "@miden-sdk/miden-sdk": ^0.15.0
-    "@miden-sdk/react": ^0.15.0
+    "@miden-sdk/miden-para": ^0.15.1
+    "@miden-sdk/miden-sdk": ^0.15.1
+    "@miden-sdk/react": ^0.15.1
     "@tanstack/react-query": ^5.0.0
     react: ^18.0.0 || ^19.0.0
     vite-plugin-node-polyfills: ^0.22.0


### PR DESCRIPTION
## Summary

Bumps `@miden-sdk/miden-sdk` (and `@miden-sdk/react` where used) from `0.15.0` to **`0.15.1`** (the just-published patch release) and bumps the package versions in lockstep.

`0.15.1` is a patch over `0.15.0` with no API changes, so there are **no source changes** — only dependency ranges, package versions, internal workspace refs, and the scaffolder's pinned versions (plus the refreshed lockfile).

## Verification

All CI gates run locally and pass; the lockfile resolves `@miden-sdk/*@0.15.1`:

- `yarn install --immutable`
- tests
- build / typecheck

Verified against `@miden-sdk/miden-sdk@0.15.1` (now the npm `latest` tag).
